### PR TITLE
Add link to reference docs in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -152,6 +152,10 @@ Install `VSCode <https://code.visualstudio.com/download>`_
 Then to debug, click View -> Output and in the dropdown will be pyls.
 To refresh VSCode, press `Cmd + r`
 
+Reference Docs
+---------------
+https://docs.contour.so/deepnote/python-language-server/README
+
 License
 -------
 


### PR DESCRIPTION
Hi there!

My name is Leo, a CS student at Brown building an automated platform for editable codebase documentation.

I generated documentation for this repository and placed a link in the README. Please feel free to try it out and let me know what you think!